### PR TITLE
Use hashed password instead of plain one.

### DIFF
--- a/PHP-FILES/user_control.php
+++ b/PHP-FILES/user_control.php
@@ -45,7 +45,7 @@ include_once 'connection.php';
 		if(!empty($email) && !empty($password)){
 			
 			$encrypted_password = md5($password);
-			$user-> does_user_exist($email,$password);
+			$user-> does_user_exist($email,$encrypted_password);
 			
 		}else{
 			echo json_encode("you must type both inputs");


### PR DESCRIPTION
Hello!

I have noticed that instead of hashed password, the plain one is used when querying database. The fix was obvious if you ask me, although I hope that changes that I propose would save someone from confusion :).

All the best!